### PR TITLE
Exclude userprofiles of given organization

### DIFF
--- a/django_server/farminsight_dashboard_backend/services/__init__.py
+++ b/django_server/farminsight_dashboard_backend/services/__init__.py
@@ -1,7 +1,7 @@
 from .fpf_services import create_fpf
 from .organization_services import create_organization, get_organization_by_name, get_organization_by_id
 from .measurement_services import store_measurements_in_influx
-from .membership_services import create_membership, get_memberships
+from .membership_services import create_membership, get_memberships, get_memberships_by_organization
 from .userprofile_services import search_userprofiles, update_userprofile_name
 from .data_services import get_all_fpf_data, get_all_sensor_data
 from .influx_services import InfluxDBManager

--- a/django_server/farminsight_dashboard_backend/services/membership_services.py
+++ b/django_server/farminsight_dashboard_backend/services/membership_services.py
@@ -22,3 +22,6 @@ def create_membership(creating_user: Userprofile, data: dict) -> MembershipSeria
 
         return membership_serializer
     raise PermissionDenied()
+
+def get_memberships_by_organization(organization_id):
+    return Membership.objects.filter(organization_id=organization_id)

--- a/django_server/farminsight_dashboard_backend/urls.py
+++ b/django_server/farminsight_dashboard_backend/urls.py
@@ -13,8 +13,8 @@ from farminsight_dashboard_backend.views import (
 )
 
 urlpatterns = [
-    path('userprofiles/own',  get_userprofile, name='get_userprofile'),
-    path('userprofiles', UserprofileView.as_view(), name='get_userprofile'),
+    path('userprofiles', get_userprofile, name='get_userprofile'),
+    path('userprofiles/<str:identifier>', UserprofileView.as_view(), name='get_userprofile'),
     path('userprofiles/<str:identifier>', UserprofileView.as_view(), name='userprofile_operations'),
     path('organizations/own', get_own_organizations, name='get_own_organizations'),
     path('organizations', post_organization, name='post_organization'),

--- a/django_server/farminsight_dashboard_backend/urls.py
+++ b/django_server/farminsight_dashboard_backend/urls.py
@@ -14,7 +14,6 @@ from farminsight_dashboard_backend.views import (
 
 urlpatterns = [
     path('userprofiles', get_userprofile, name='get_userprofile'),
-    path('userprofiles/<str:identifier>', UserprofileView.as_view(), name='get_userprofile'),
     path('userprofiles/<str:identifier>', UserprofileView.as_view(), name='userprofile_operations'),
     path('organizations/own', get_own_organizations, name='get_own_organizations'),
     path('organizations', post_organization, name='post_organization'),

--- a/django_server/farminsight_dashboard_backend/urls.py
+++ b/django_server/farminsight_dashboard_backend/urls.py
@@ -13,7 +13,8 @@ from farminsight_dashboard_backend.views import (
 )
 
 urlpatterns = [
-    path('userprofiles',  get_userprofile, name='get_userprofile'),
+    path('userprofiles/own',  get_userprofile, name='get_userprofile'),
+    path('userprofiles', UserprofileView.as_view(), name='get_userprofile'),
     path('userprofiles/<str:identifier>', UserprofileView.as_view(), name='userprofile_operations'),
     path('organizations/own', get_own_organizations, name='get_own_organizations'),
     path('organizations', post_organization, name='post_organization'),

--- a/django_server/farminsight_dashboard_backend/views/userprofile_views.py
+++ b/django_server/farminsight_dashboard_backend/views/userprofile_views.py
@@ -11,17 +11,16 @@ from rest_framework.decorators import api_view, permission_classes
 class UserprofileView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request):
+    def get(self, request, identifier):
         """
         Search userprofile by string (name or email)
         Exclude userprofiles of an organization optionally with query param exclude_organization_id.
+        :param identifier: Name or email to be searched for
         :param request:
         :return:
         """
-        search_string = request.query_params.get("search_string", "")
         exclude_organization_id = request.query_params.get("exclude_organization_id", None)
-
-        userprofiles = search_userprofiles(search_string)
+        userprofiles = search_userprofiles(identifier)
 
         if exclude_organization_id:
             memberships_to_exclude = get_memberships_by_organization(exclude_organization_id)

--- a/django_server/farminsight_dashboard_backend/views/userprofile_views.py
+++ b/django_server/farminsight_dashboard_backend/views/userprofile_views.py
@@ -1,17 +1,34 @@
+from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from farminsight_dashboard_backend.serializers import UserprofileSerializer
-from farminsight_dashboard_backend.services import search_userprofiles, update_userprofile_name
+from farminsight_dashboard_backend.services import search_userprofiles, update_userprofile_name, \
+    get_memberships_by_organization
 from rest_framework.decorators import api_view, permission_classes
 
 
 class UserprofileView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request, identifier: str):
-        userprofiles = search_userprofiles(identifier)[:10]
-        return Response(UserprofileSerializer(userprofiles, many=True).data)
+    def get(self, request):
+        """
+        Search userprofile by string (name or email)
+        Exclude userprofiles of an organization optionally with query param exclude_organization_id.
+        :param request:
+        :return:
+        """
+        search_string = request.query_params.get("search_string", "")
+        exclude_organization_id = request.query_params.get("exclude_organization_id", None)
+
+        userprofiles = search_userprofiles(search_string)
+
+        if exclude_organization_id:
+            memberships_to_exclude = get_memberships_by_organization(exclude_organization_id)
+            userprofile_ids_to_exclude = memberships_to_exclude.values_list('userprofile_id', flat=True)
+            userprofiles = userprofiles.exclude(id__in=userprofile_ids_to_exclude)
+
+        return Response(UserprofileSerializer(userprofiles[:10], many=True).data)
 
     def put(self, request, identifier):
         updated_userprofile = update_userprofile_name(identifier, request.data.get('name'))


### PR DESCRIPTION
Reworked the userprofile endpoints to (optionally) exclude userprofiles of given organization.
GET my userprofile becomes /userprofiles/own
GET userprofiles by name becomes  /userprofiles with 2 query params: exclude_organization_id and search_string

other api design ideas are welcome, if we want to have this feature in backend.
Api documentation to be adjusted accordingly on okay for merge.